### PR TITLE
Rename the project name to `qiwis`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 [run]
-omit = ./tests/*
+omit = ./test.py
 
 [report]
 exclude_lines =

--- a/.pylintrc_test
+++ b/.pylintrc_test
@@ -16,4 +16,4 @@ disable=
     protected-access,
 
 [TYPECHECK]
-ignored-modules=qiwi
+ignored-modules=qiwis

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
   <img width="40%" alt="image" src="https://user-images.githubusercontent.com/65724072/235589514-ed021c0c-cf20-4ba1-b8af-3b1d0da65362.svg">
 </p>
 
-[![Pylint](https://github.com/snu-quiqcl/qiwi/actions/workflows/pylint.yml/badge.svg)](https://github.com/snu-quiqcl/qiwi/actions/workflows/pylint.yml)
+[![Pylint](https://github.com/snu-quiqcl/qiwis/actions/workflows/pylint.yml/badge.svg)](https://github.com/snu-quiqcl/qiwis/actions/workflows/pylint.yml)
 
-[![unittest](https://github.com/snu-quiqcl/qiwi/actions/workflows/unittest.yml/badge.svg)](https://github.com/snu-quiqcl/qiwi/actions/workflows/unittest.yml)
+[![unittest](https://github.com/snu-quiqcl/qiwis/actions/workflows/unittest.yml/badge.svg)](https://github.com/snu-quiqcl/qiwis/actions/workflows/unittest.yml)
 
-# qiwi
-QIWI (**Q**u**I**qcl **W**idget **I**ntegration framework) is a framework for integration of PyQt widgets where they can communicate with each other. This project is mainly developed for trapped ion experiment controller GUI in SNU QuIQCL.
+# qiwis
+QIWIS (**Q**u**I**qcl **W**idget **I**ntegration **S**oftware) is a framework for integration of PyQt widgets where they can communicate with each other. This project is mainly developed for trapped ion experiment controller GUI in SNU QuIQCL.
 
 ## How to download and install
 One of the below:
 - Using released version (_recommended_)
-1. `pip install git_https://github.com/snu-quiqcl/qiwi.git@v2.0.0`
+1. `pip install git_https://github.com/snu-quiqcl/qiwis.git@v2.0.0`
 
 - Using git directly
 1. `git clone ${url}`: The default branch is `develop`, not `main`. There is no guarantee for stability.
@@ -21,4 +21,4 @@ One of the below:
 ## How to use
 In the repository, just do like as below:
 
-`python -m qiwi (-s ${setup_file))`.
+`python -m qiwis (-s ${setup_file))`.

--- a/examples/datacalc.py
+++ b/examples/datacalc.py
@@ -9,7 +9,7 @@ from typing import Any, Optional, Dict, Tuple
 from PyQt5.QtCore import QObject, pyqtSlot
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QComboBox, QPushButton, QLabel
 
-from qiwi import BaseApp
+from qiwis import BaseApp
 from examples.backend import read
 
 class ViewerFrame(QWidget):

--- a/examples/dbmgr.py
+++ b/examples/dbmgr.py
@@ -10,7 +10,7 @@ from PyQt5.QtCore import QObject, pyqtSlot
 from PyQt5.QtWidgets import (QWidget, QLabel, QPushButton, QFileDialog,
                              QHBoxLayout, QVBoxLayout, QListWidget, QListWidgetItem)
 
-from qiwi import AppInfo, BaseApp
+from qiwis import AppInfo, BaseApp
 
 class DBWidget(QWidget):
     """Widget for showing a database.
@@ -91,7 +91,7 @@ class DBMgrApp(BaseApp):
           Each element is a namedtuple which represents a database.
           It has two elements; file name and absolute path.
         isDatacalcOpen: True if a datacalc app is open, and False if it is close.
-        openCloseDatacalcResult: The latest qiwicall result 
+        openCloseDatacalcResult: The latest qiwiscall result 
           which requests for opening or closing a datacalc app.
         managerFrame: A frame that manages and shows available databases.
     """
@@ -181,14 +181,14 @@ class DBMgrApp(BaseApp):
         """
         if self.openCloseDatacalcResult is not None:
             if not self.openCloseDatacalcResult.done:
-                print("DBMgrApp.openCloseDatacalc(): The previous qiwicall must be done.")
+                print("DBMgrApp.openCloseDatacalc(): The previous qiwiscall must be done.")
                 return
             if self.openCloseDatacalcResult.success:
                 self.isDatacalcOpen = not self.isDatacalcOpen
         if self.isDatacalcOpen:
-            self.openCloseDatacalcResult = self.qiwicall.destroyApp(name="datacalc")
+            self.openCloseDatacalcResult = self.qiwiscall.destroyApp(name="datacalc")
         else:
-            self.openCloseDatacalcResult = self.qiwicall.createApp(
+            self.openCloseDatacalcResult = self.qiwiscall.createApp(
                 name="datacalc",
                 info=AppInfo(
                     module="examples.datacalc",

--- a/examples/logger.py
+++ b/examples/logger.py
@@ -8,7 +8,7 @@ from typing import Any, Optional, Tuple
 from PyQt5.QtCore import QObject, pyqtSlot, pyqtSignal
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QPushButton, QTextEdit, QLabel, QDialogButtonBox
 
-from qiwi import BaseApp
+from qiwis import BaseApp
 
 class LoggerFrame(QWidget):
     """Frame for logging.

--- a/examples/numgen.py
+++ b/examples/numgen.py
@@ -10,7 +10,7 @@ from typing import Any, Optional, Tuple, Union
 from PyQt5.QtCore import QObject, pyqtSlot
 from PyQt5.QtWidgets import QWidget, QComboBox, QPushButton, QLabel, QVBoxLayout
 
-from qiwi import BaseApp
+from qiwis import BaseApp
 from examples.backend import generate, write
 
 class GeneratorFrame(QWidget):
@@ -161,7 +161,7 @@ class NumGenApp(BaseApp):
         num = generate()
         if not self.isGenerated:
             self.isGenerated = True
-            self.qiwicall.updateFrames(name=self.name)
+            self.qiwiscall.updateFrames(name=self.name)
         self.viewerFrame.numberLabel.setText(f"generated number: {num}")
         self.broadcast("log", f"Generated number: {num}.")
         # save the generated number

--- a/examples/poller.py
+++ b/examples/poller.py
@@ -8,7 +8,7 @@ from typing import Any, Optional, Tuple
 from PyQt5.QtCore import QObject, pyqtSlot, QTimer
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QComboBox, QSpinBox, QLabel
 
-from qiwi import BaseApp
+from qiwis import BaseApp
 from examples.backend import poll, write
 
 class ViewerFrame(QWidget):

--- a/setup.py
+++ b/setup.py
@@ -10,20 +10,20 @@ if sys.version_info[:2] < (3, 7):
     sys.exit()
 
 setup(
-    name="qiwi",
+    name="qiwis",
     version="2.0.0",  # indicate the following version
     author="QuIQCL",
     author_email="kangz12345@snu.ac.kr",
-    url="https://github.com/snu-quiqcl/qiwi",
-    description="SNU widget integration framework for PyQt",
+    url="https://github.com/snu-quiqcl/qiwis",
+    description="QuIqcl Widget Integration Software",
     long_description=
         "A framework for integration of PyQt widgets where they can communicate with each other. "
         "This project is mainly developed for trapped ion experiment controller GUI in SNU QuIQCL.",
-    download_url="https://github.com/snu-quiqcl/qiwi/releases/tag/v2.0.0",
+    download_url="https://github.com/snu-quiqcl/qiwis/releases/tag/v2.0.0",
     license="MIT license",
     install_requires=["pyqt5"],
-    packages=find_packages(include=["qiwi"]),
+    packages=find_packages(include=["qiwis"]),
     entry_points={
-        "console_scripts": ["qiwi = qiwi:main"]
+        "console_scripts": ["qiwis = qiwis:main"]
     }
 )

--- a/test.py
+++ b/test.py
@@ -1,5 +1,5 @@
 """
-Module for testing qiwi module.
+Module for testing qiwis module.
 """
 
 import collections.abc
@@ -13,10 +13,10 @@ from typing import Any, Optional, Mapping, Iterable
 from PyQt5.QtCore import QObject
 from PyQt5.QtWidgets import QApplication, QMessageBox, QWidget
 
-import qiwi
+import qiwis
 
 APP_INFOS = {
-    "app1": qiwi.AppInfo(
+    "app1": qiwis.AppInfo(
         module="module1",
         cls="cls1",
         path="path1",
@@ -25,7 +25,7 @@ APP_INFOS = {
         channel=["ch1", "ch2"],
         args={"arg1": "value1"}
     ),
-    "app2": qiwi.AppInfo(
+    "app2": qiwis.AppInfo(
         module="module2",
         cls="cls2"
     )
@@ -74,22 +74,22 @@ class QiwiTestWithApps(unittest.TestCase):
         self.channels = set()
         for appInfo in APP_INFOS.values():
             self.channels.update(appInfo.channel)
-        self.qiwi = qiwi.Qiwi(APP_INFOS)
+        self.qiwis = qiwis.Qiwi(APP_INFOS)
 
     def doCleanups(self):
         self.import_module_patcher.stop()
 
     def test_init(self):
-        self.assertEqual(self.qiwi.appInfos, APP_INFOS)
+        self.assertEqual(self.qiwis.appInfos, APP_INFOS)
         for name, info in APP_INFOS.items():
             self.mocked_import_module.assert_any_call(info.module)
-            self.assertEqual(self.qiwi._apps[name].cls, info.cls)
-            self.assertIn(name, self.qiwi._dockWidgets)
+            self.assertEqual(self.qiwis._apps[name].cls, info.cls)
+            self.assertIn(name, self.qiwis._dockWidgets)
         for channel in self.channels:
-            self.assertIn(channel, self.qiwi._subscribers)
+            self.assertIn(channel, self.qiwis._subscribers)
 
     def test_app_names(self):
-        appNamesSet = set(self.qiwi.appNames())
+        appNamesSet = set(self.qiwis.appNames())
         self.assertEqual(appNamesSet, set(APP_INFOS))
 
     def test_create_app(self):
@@ -98,63 +98,63 @@ class QiwiTestWithApps(unittest.TestCase):
         app_.frames.return_value = (QWidget(),)
         cls = mock.MagicMock(return_value=app_)
         setattr(self.mocked_import_module.return_value, "cls3", cls)
-        self.qiwi.createApp(
+        self.qiwis.createApp(
             "app3",
-            qiwi.AppInfo(**{"module": "module3", "cls": "cls3", "channel": ["ch1"]})
+            qiwis.AppInfo(**{"module": "module3", "cls": "cls3", "channel": ["ch1"]})
         )
         self.mocked_import_module.assert_called_with("module3")
-        self.assertEqual(self.qiwi._apps["app3"].cls, "cls3")
-        self.assertIn("app3", self.qiwi._dockWidgets)
-        self.assertIn("app3", self.qiwi._subscribers["ch1"])
+        self.assertEqual(self.qiwis._apps["app3"].cls, "cls3")
+        self.assertIn("app3", self.qiwis._dockWidgets)
+        self.assertIn("app3", self.qiwis._subscribers["ch1"])
 
     def test_destroy_app(self):
         for name, info in APP_INFOS.items():
-            self.qiwi.destroyApp(name)
-            self.assertNotIn(name, self.qiwi._apps)
-            self.assertNotIn(name, self.qiwi._dockWidgets)
+            self.qiwis.destroyApp(name)
+            self.assertNotIn(name, self.qiwis._apps)
+            self.assertNotIn(name, self.qiwis._dockWidgets)
             for channel in info.channel:
-                self.assertNotIn(name, self.qiwi._subscribers[channel])
+                self.assertNotIn(name, self.qiwis._subscribers[channel])
 
     def test_update_frames_inclusive(self):
         """Tests for the case where a new frame is added in the return of frames()."""
-        orgFramesSet = {dockWidget.widget() for dockWidget in self.qiwi._dockWidgets["app1"]}
+        orgFramesSet = {dockWidget.widget() for dockWidget in self.qiwis._dockWidgets["app1"]}
         newFramesSet = orgFramesSet | {QWidget()}
-        self.qiwi._apps["app1"].frames.return_value = tuple(newFramesSet)
-        self.qiwi.updateFrames("app1")
-        finalFramesSet = {dockWidget.widget() for dockWidget in self.qiwi._dockWidgets["app1"]}
+        self.qiwis._apps["app1"].frames.return_value = tuple(newFramesSet)
+        self.qiwis.updateFrames("app1")
+        finalFramesSet = {dockWidget.widget() for dockWidget in self.qiwis._dockWidgets["app1"]}
         self.assertEqual(finalFramesSet, newFramesSet)
 
     def test_update_frames_exclusive(self):
         """Tests for the case where a new frame replaced the return of frames()."""
-        orgFramesSet = {dockWidget.widget() for dockWidget in self.qiwi._dockWidgets["app1"]}
+        orgFramesSet = {dockWidget.widget() for dockWidget in self.qiwis._dockWidgets["app1"]}
         newFramesSet = {QWidget()}
-        self.qiwi._apps["app1"].frames.return_value = tuple(newFramesSet)
-        self.qiwi.updateFrames("app1")
-        finalFramesSet = {dockWidget.widget() for dockWidget in self.qiwi._dockWidgets["app1"]}
+        self.qiwis._apps["app1"].frames.return_value = tuple(newFramesSet)
+        self.qiwis.updateFrames("app1")
+        finalFramesSet = {dockWidget.widget() for dockWidget in self.qiwis._dockWidgets["app1"]}
         self.assertFalse(finalFramesSet & orgFramesSet)
         self.assertEqual(finalFramesSet, newFramesSet)
 
     def test_channel_names(self):
-        channelNamesSet = set(self.qiwi.channelNames())
+        channelNamesSet = set(self.qiwis.channelNames())
         self.assertEqual(channelNamesSet, self.channels)
 
     def test_subscriber_names(self):
         for channel in self.channels:
-            subscriberNamesSet = set(self.qiwi.subscriberNames(channel))
+            subscriberNamesSet = set(self.qiwis.subscriberNames(channel))
             self.assertEqual(
                 subscriberNamesSet,
                 {name for name, info in APP_INFOS.items() if channel in info.channel}
             )
 
     def test_unsubcribe(self):
-        self.assertEqual(self.qiwi.unsubscribe("app1", "ch1"), True)
-        self.assertNotIn("app1", self.qiwi._subscribers["ch1"])
-        self.assertEqual(self.qiwi.unsubscribe("app2", "ch1"), False)
+        self.assertEqual(self.qiwis.unsubscribe("app1", "ch1"), True)
+        self.assertNotIn("app1", self.qiwis._subscribers["ch1"])
+        self.assertEqual(self.qiwis.unsubscribe("app2", "ch1"), False)
 
     def test_broadcast(self):
         for channelName in self.channels:
-            self.qiwi._broadcast(channelName, "test_msg")
-        for name, app_ in self.qiwi._apps.items():
+            self.qiwis._broadcast(channelName, "test_msg")
+        for name, app_ in self.qiwis._apps.items():
             self.assertEqual(len(APP_INFOS[name].channel), app_.received.emit.call_count)
 
 
@@ -162,51 +162,51 @@ class QiwiTestWithoutApps(unittest.TestCase):
     """Unit test for Qiwi class without apps."""
 
     def setUp(self):
-        self.qiwi = qiwi.Qiwi()
+        self.qiwis = qiwis.Qiwi()
 
-    def help_qiwicall(
+    def help_qiwiscall(
         self,
         value: Any,
         result_string: str,
         error: Optional[Exception] = None,
         dumps: Iterable = (),
     ):
-        """Helper method for testing _qiwicall().
+        """Helper method for testing _qiwiscall().
         
         Args:
-            value: The actual return value of the qiwi-call.
-            result_string: The qiwi.dumps()-ed string of the result object that should be
-              generated after the qiwi-call.
-            error: The Exception instance that should have occurred during the qiwi-call.
+            value: The actual return value of the qiwiscall.
+            result_string: The qiwis.dumps()-ed string of the result object that should be
+              generated after the qiwiscall.
+            error: The Exception instance that should have occurred during the qiwiscall.
               None if no exception is expected.
-            dumps: A sequence of return values of the mocked qiwi.dumps().
+            dumps: A sequence of return values of the mocked qiwis.dumps().
               It will be given as side_effect. Moreover, the number of calls of
-              qiwi.dumps() should be the same as the lenght of the given iterable.
+              qiwis.dumps() should be the same as the lenght of the given iterable.
         """
         msg = json.dumps({"call": "callForTest", "args": {}})
-        with mock.patch.multiple(self.qiwi, _handleQiwicall=mock.DEFAULT, _apps=mock.DEFAULT):
+        with mock.patch.multiple(self.qiwis, _handleQiwicall=mock.DEFAULT, _apps=mock.DEFAULT):
             if error is None:
-                self.qiwi._handleQiwicall.return_value = value
+                self.qiwis._handleQiwicall.return_value = value
             else:
-                self.qiwi._handleQiwicall.side_effect = error
-            with mock.patch("qiwi.dumps") as mocked_dumps:
+                self.qiwis._handleQiwicall.side_effect = error
+            with mock.patch("qiwis.dumps") as mocked_dumps:
                 mocked_dumps.side_effect = dumps
-                self.qiwi._qiwicall(sender="sender", msg=msg)
+                self.qiwis._qiwiscall(sender="sender", msg=msg)
                 self.assertEqual(len(mocked_dumps.mock_calls), len(dumps))
-            mocked_signal = self.qiwi._apps["sender"].qiwicallReturned
+            mocked_signal = self.qiwis._apps["sender"].qiwiscallReturned
             mocked_signal.emit.assert_called_once_with(msg, result_string)
 
-    def test_qiwicall_primitive(self):
-        """The qiwicall returns a primitive type value, which can be JSONified."""
+    def test_qiwiscall_primitive(self):
+        """The qiwiscall returns a primitive type value, which can be JSONified."""
         value = [1.5, True, None, "abc"]
         result_string = json.dumps({"done": True, "success": True, "value": value, "error": None})
         dumps = (result_string,)
-        self.help_qiwicall(value, result_string, dumps=dumps)
+        self.help_qiwiscall(value, result_string, dumps=dumps)
 
-    def test_qiwicall_serializable(self):
-        """The qiwicall returns a Serializable type value."""
+    def test_qiwiscall_serializable(self):
+        """The qiwiscall returns a Serializable type value."""
         @dataclasses.dataclass
-        class ClassForTest(qiwi.Serializable):
+        class ClassForTest(qiwis.Serializable):
             a: str
         value = ClassForTest(a="abc")
         value_string = json.dumps({"a": "abc"})
@@ -217,10 +217,10 @@ class QiwiTestWithoutApps(unittest.TestCase):
             "error": None,
         })
         dumps = (value_string, result_string)
-        self.help_qiwicall(value, result_string, dumps=dumps)
+        self.help_qiwiscall(value, result_string, dumps=dumps)
 
-    def test_qiwicall_exception(self):
-        """The qiwicall raises an exception."""
+    def test_qiwiscall_exception(self):
+        """The qiwiscall raises an exception."""
         class ExceptionForTest(Exception):
             """Temporary exception only for this test."""
         error = ExceptionForTest("test")
@@ -231,18 +231,18 @@ class QiwiTestWithoutApps(unittest.TestCase):
             "error": repr(error),
         })
         dumps = (result_string,)
-        self.help_qiwicall(None, result_string, error, dumps=dumps)
+        self.help_qiwiscall(None, result_string, error, dumps=dumps)
 
     def test_parse_args_primitive(self):
         def call_for_test(number: float, boolean: bool, string: str):  # pylint: disable=unused-argument
             """A dummy function for testing, which has only primitive type arguments."""
         args = {"number": 1.5, "boolean": True, "string": "abc"}
-        parsed_args = self.qiwi._parseArgs(call_for_test, args)
+        parsed_args = self.qiwis._parseArgs(call_for_test, args)
         self.assertEqual(args, parsed_args)
 
     def test_parse_args_serializable(self):
         @dataclasses.dataclass
-        class ClassForTest(qiwi.Serializable):
+        class ClassForTest(qiwis.Serializable):
             number: float
             boolean: bool
             string: str
@@ -260,71 +260,71 @@ class QiwiTestWithoutApps(unittest.TestCase):
         }
         args = {"arg1": ClassForTest(**fields1), "arg2": ClassForTest(**fields2)}
         json_args = {"arg1": json.dumps(fields1), "arg2": json.dumps(fields2)}
-        parsed_args = self.qiwi._parseArgs(call_for_test, json_args)
+        parsed_args = self.qiwis._parseArgs(call_for_test, json_args)
         self.assertEqual(args, parsed_args)
 
-@mock.patch("qiwi.loads")
-@mock.patch("qiwi.QMessageBox.warning")
+@mock.patch("qiwis.loads")
+@mock.patch("qiwis.QMessageBox.warning")
 class HandleQiwicallTest(unittest.TestCase):
     """Unit test for Qiwi._handleQiwicall()."""
 
     def setUp(self):
-        self.qiwi = qiwi.Qiwi()
+        self.qiwis = qiwis.Qiwi()
 
     def test_ok(self, mocked_warning, mocked_loads):
         args = {"a": 123, "b": "ABC"}
-        info = qiwi.QiwicallInfo(call="callForTest", args=args)
+        info = qiwis.QiwicallInfo(call="callForTest", args=args)
         msg = json.dumps({"call": "callForTest", "args": args})
         mocked_loads.return_value = info
         mocked_warning.return_value = QMessageBox.Ok
-        with mock.patch.multiple(self.qiwi, create=True,
+        with mock.patch.multiple(self.qiwis, create=True,
                                  callForTest=mock.DEFAULT, _parseArgs=mock.DEFAULT):
-            self.qiwi._parseArgs.return_value = args
-            self.qiwi._handleQiwicall(sender="sender", msg=msg)
-            self.qiwi.callForTest.assert_called_once_with(**args)
-            self.qiwi._parseArgs.assert_called_once_with(self.qiwi.callForTest, args)
+            self.qiwis._parseArgs.return_value = args
+            self.qiwis._handleQiwicall(sender="sender", msg=msg)
+            self.qiwis.callForTest.assert_called_once_with(**args)
+            self.qiwis._parseArgs.assert_called_once_with(self.qiwis.callForTest, args)
         mocked_loads.assert_called_once()
         mocked_warning.assert_called_once()
 
     def test_cancel(self, mocked_warning, mocked_loads):
         args = {"a": 123, "b": "ABC"}
-        info = qiwi.QiwicallInfo(call="callForTest", args=args)
+        info = qiwis.QiwicallInfo(call="callForTest", args=args)
         msg = json.dumps({"call": "callForTest", "args": args})
         mocked_loads.return_value = info
         mocked_warning.return_value = QMessageBox.Cancel
-        with mock.patch.multiple(self.qiwi, create=True,
+        with mock.patch.multiple(self.qiwis, create=True,
                                  callForTest=mock.DEFAULT, _parseArgs=mock.DEFAULT):
-            self.qiwi._parseArgs.return_value = args
+            self.qiwis._parseArgs.return_value = args
             with self.assertRaises(RuntimeError):
-                self.qiwi._handleQiwicall(sender="sender", msg=msg)
-            self.qiwi.callForTest.assert_not_called()
-            self.qiwi._parseArgs.assert_called_once_with(self.qiwi.callForTest, args)
+                self.qiwis._handleQiwicall(sender="sender", msg=msg)
+            self.qiwis.callForTest.assert_not_called()
+            self.qiwis._parseArgs.assert_called_once_with(self.qiwis.callForTest, args)
         mocked_loads.assert_called_once()
         mocked_warning.assert_called_once()
 
     def test_non_public(self, mocked_warning, mocked_loads):
         args = {"a": 123, "b": "ABC"}
-        info = qiwi.QiwicallInfo(call="_callForTest", args=args)
+        info = qiwis.QiwicallInfo(call="_callForTest", args=args)
         msg = json.dumps({"call": "_callForTest", "args": args})
         mocked_loads.return_value = info
-        with mock.patch.multiple(self.qiwi, create=True,
+        with mock.patch.multiple(self.qiwis, create=True,
                                  _callForTest=mock.DEFAULT, _parseArgs=mock.DEFAULT):
             with self.assertRaises(ValueError):
-                self.qiwi._handleQiwicall(sender="sender", msg=msg)
-            self.qiwi._callForTest.assert_not_called()
-            self.qiwi._parseArgs.assert_not_called()
+                self.qiwis._handleQiwicall(sender="sender", msg=msg)
+            self.qiwis._callForTest.assert_not_called()
+            self.qiwis._parseArgs.assert_not_called()
         mocked_loads.assert_called_once()
         mocked_warning.assert_not_called()
 
     def test_not_existing_method(self, mocked_warning, mocked_loads):
         args = {"a": 123, "b": "ABC"}
-        info = qiwi.QiwicallInfo(call="callForTest", args=args)
+        info = qiwis.QiwicallInfo(call="callForTest", args=args)
         msg = json.dumps({"call": "callForTest", "args": args})
         mocked_loads.return_value = info
-        with mock.patch.multiple(self.qiwi, create=True, _parseArgs=mock.DEFAULT):
+        with mock.patch.multiple(self.qiwis, create=True, _parseArgs=mock.DEFAULT):
             with self.assertRaises(AttributeError):
-                self.qiwi._handleQiwicall(sender="sender", msg=msg)
-            self.qiwi._parseArgs.assert_not_called()
+                self.qiwis._handleQiwicall(sender="sender", msg=msg)
+            self.qiwis._parseArgs.assert_not_called()
         mocked_loads.assert_called_once()
         mocked_warning.assert_not_called()
 
@@ -333,13 +333,13 @@ class BaseAppTest(unittest.TestCase):
     """Unit test for BaseApp class."""
 
     def setUp(self):
-        self.app = qiwi.BaseApp("name")
+        self.app = qiwis.BaseApp("name")
 
     def test_init(self):
         self.assertEqual(self.app.name, "name")
 
     def test_set_parent(self):
-        qiwi.BaseApp("name", QObject())
+        qiwis.BaseApp("name", QObject())
 
     def test_frames(self):
         self.assertIsInstance(self.app.frames(), collections.abc.Iterable)
@@ -364,60 +364,60 @@ class BaseAppTest(unittest.TestCase):
         self.app._receivedMessage("ch1", '"msg1" "msg2"')
         self.app.receivedSlot.assert_not_called()
 
-    def test_received_qiwicall_result(self):
-        self.app.qiwicall.update_result = mock.MagicMock()
+    def test_received_qiwiscall_result(self):
+        self.app.qiwiscall.update_result = mock.MagicMock()
         self.app._receivedQiwicallResult(
             "request", '{"done": true, "success": true, "value": null, "error": null}'
         )
-        self.app.qiwicall.update_result.assert_called_once_with(
+        self.app.qiwiscall.update_result.assert_called_once_with(
             "request",
-            qiwi.QiwicallResult(done=True, success=True)
+            qiwis.QiwicallResult(done=True, success=True)
         )
 
-    def test_received_qiwicall_result_exception(self):
-        self.app.qiwicall.update_result = mock.MagicMock()
+    def test_received_qiwiscall_result_exception(self):
+        self.app.qiwiscall.update_result = mock.MagicMock()
         self.app._receivedQiwicallResult(
             "request", '{"done": "tr" "ue", "success": true, "value": null, "error": null}'
         )
-        self.app.qiwicall.update_result.assert_not_called()
+        self.app.qiwiscall.update_result.assert_not_called()
 
 
 class QiwicallProxyTest(unittest.TestCase):
     """Unit test for QiwicallProxy class."""
 
     def setUp(self):
-        self.qiwicall = qiwi.QiwicallProxy(mock.MagicMock())
+        self.qiwiscall = qiwis.QiwicallProxy(mock.MagicMock())
 
     def help_proxy(self, msg: str, args: Mapping[str, Any], dumps: Iterable):
         """Helper method for testing proxy.
         
         Args:
-            msg: The qiwi-call request message.
+            msg: The qiwiscall request message.
             args: A keyword argument mapping for calling the proxy.
-            dumps: Expected return values of qiwi.dumps() during the proxied qiwi-call.
+            dumps: Expected return values of qiwis.dumps() during the proxied qiwiscall.
               It will be given as side_effect. The number of calls should be the same as
               the length of the given iterable.
         """
-        with mock.patch.object(self.qiwicall, "results", {}):
-            with mock.patch("qiwi.dumps") as mocked_dumps:
+        with mock.patch.object(self.qiwiscall, "results", {}):
+            with mock.patch("qiwis.dumps") as mocked_dumps:
                 mocked_dumps.side_effect = dumps
-                result = self.qiwicall.callForTest(**args)
+                result = self.qiwiscall.callForTest(**args)
                 self.assertEqual(len(mocked_dumps.mock_calls), len(dumps))
-            self.qiwicall.requested.emit.assert_called_once_with(msg)
-            self.assertIs(result, self.qiwicall.results[msg])
-            self.assertEqual(result, qiwi.QiwicallResult(done=False, success=False))
+            self.qiwiscall.requested.emit.assert_called_once_with(msg)
+            self.assertIs(result, self.qiwiscall.results[msg])
+            self.assertEqual(result, qiwis.QiwicallResult(done=False, success=False))
 
     def test_proxy_primitive(self):
-        """Tests a proxied qiwicall with primitive type arguments."""
+        """Tests a proxied qiwiscall with primitive type arguments."""
         args = {"number": 1.5, "boolean": True, "string": "abc"}
         msg = json.dumps({"call": "callForTest", "args": args})
         dumps = (msg,)
         self.help_proxy(msg, args, dumps)
 
     def test_proxy_serializable(self):
-        """Tests a proxied qiwicall with Serializable type arguments."""
+        """Tests a proxied qiwiscall with Serializable type arguments."""
         @dataclasses.dataclass
-        class ClassForTest(qiwi.Serializable):
+        class ClassForTest(qiwis.Serializable):
             number: float
             boolean: bool
             string: str
@@ -434,104 +434,104 @@ class QiwicallProxyTest(unittest.TestCase):
         self.help_proxy(msg, args, dumps)
 
     def test_proxy_duplicate(self):
-        """Tests a duplicate proxied qiwicall.
+        """Tests a duplicate proxied qiwiscall.
         
         The new one should be accepted and the previous one should be discarded.
         """
         args = {"a": 123}
         msg = json.dumps({"call": "callForTest", "args": args})
-        with mock.patch.object(self.qiwicall, "results", {}):
-            with mock.patch("qiwi.dumps") as mocked_dumps:
+        with mock.patch.object(self.qiwiscall, "results", {}):
+            with mock.patch("qiwis.dumps") as mocked_dumps:
                 mocked_dumps.side_effect = (msg, msg)
-                result1 = self.qiwicall.callForTest(**args)
-                result2 = self.qiwicall.callForTest(**args)
+                result1 = self.qiwiscall.callForTest(**args)
+                result2 = self.qiwiscall.callForTest(**args)
                 self.assertEqual(len(mocked_dumps.mock_calls), 2)
             self.assertSequenceEqual(
-                self.qiwicall.requested.emit.mock_calls,
+                self.qiwiscall.requested.emit.mock_calls,
                 (mock.call(msg), mock.call(msg)),
             )
-            self.assertIs(result2, self.qiwicall.results[msg])
-            self.assertEqual(result2, qiwi.QiwicallResult(done=False, success=False))
+            self.assertIs(result2, self.qiwiscall.results[msg])
+            self.assertEqual(result2, qiwis.QiwicallResult(done=False, success=False))
             self.assertEqual(result1, result2)
 
     def test_update_result_success(self):
-        old_result = qiwi.QiwicallResult(done=False, success=False)
-        new_result = qiwi.QiwicallResult(done=True, success=True, value=0)
-        with mock.patch.object(self.qiwicall, "results", {"request": old_result}):
-            self.qiwicall.update_result("request", new_result)
+        old_result = qiwis.QiwicallResult(done=False, success=False)
+        new_result = qiwis.QiwicallResult(done=True, success=True, value=0)
+        with mock.patch.object(self.qiwiscall, "results", {"request": old_result}):
+            self.qiwiscall.update_result("request", new_result)
             self.assertEqual(old_result, new_result)
-            self.assertNotIn("request", self.qiwicall.results)
+            self.assertNotIn("request", self.qiwiscall.results)
 
     def test_update_result_error(self):
-        old_result = qiwi.QiwicallResult(done=False, success=False)
-        new_result = qiwi.QiwicallResult(done=True, success=False, error=RuntimeError("test"))
-        with mock.patch.object(self.qiwicall, "results", {"request": old_result}):
-            self.qiwicall.update_result("request", new_result)
+        old_result = qiwis.QiwicallResult(done=False, success=False)
+        new_result = qiwis.QiwicallResult(done=True, success=False, error=RuntimeError("test"))
+        with mock.patch.object(self.qiwiscall, "results", {"request": old_result}):
+            self.qiwiscall.update_result("request", new_result)
             self.assertEqual(old_result, new_result)
-            self.assertNotIn("request", self.qiwicall.results)
+            self.assertNotIn("request", self.qiwiscall.results)
 
     def test_update_result_no_discard(self):
-        old_result = qiwi.QiwicallResult(done=False, success=False)
-        new_result = qiwi.QiwicallResult(done=True, success=True, value=0)
-        with mock.patch.object(self.qiwicall, "results", {"request": old_result}):
-            self.qiwicall.update_result("request", new_result, discard=False)
+        old_result = qiwis.QiwicallResult(done=False, success=False)
+        new_result = qiwis.QiwicallResult(done=True, success=True, value=0)
+        with mock.patch.object(self.qiwiscall, "results", {"request": old_result}):
+            self.qiwiscall.update_result("request", new_result, discard=False)
             self.assertEqual(old_result, new_result)
-            self.assertIs(old_result, self.qiwicall.results["request"])
+            self.assertIs(old_result, self.qiwiscall.results["request"])
 
     def test_update_result_not_exist(self):
         """When the request is not in the results dictionary, it is ignored."""
-        new_result = qiwi.QiwicallResult(done=True, success=True, value=0)
-        with mock.patch.object(self.qiwicall, "results", {}):
-            self.qiwicall.update_result("request", new_result)
-            self.assertNotIn("request", self.qiwicall.results)
+        new_result = qiwis.QiwicallResult(done=True, success=True, value=0)
+        with mock.patch.object(self.qiwiscall, "results", {}):
+            self.qiwiscall.update_result("request", new_result)
+            self.assertNotIn("request", self.qiwiscall.results)
 
 
 class QiwiFunctionTest(unittest.TestCase):
     """Unit test for functions."""
 
     def test_loads(self):
-        self.assertEqual(qiwi.loads(qiwi.AppInfo, APP_JSONS["app1"]), APP_INFOS["app1"])
-        self.assertEqual(qiwi.loads(qiwi.AppInfo, APP_JSONS["app2_default"]), APP_INFOS["app2"])
+        self.assertEqual(qiwis.loads(qiwis.AppInfo, APP_JSONS["app1"]), APP_INFOS["app1"])
+        self.assertEqual(qiwis.loads(qiwis.AppInfo, APP_JSONS["app2_default"]), APP_INFOS["app2"])
 
     def test_dumps(self):
-        self.assertEqual(qiwi.dumps(APP_INFOS["app1"]), APP_JSONS["app1"])
-        self.assertEqual(qiwi.dumps(APP_INFOS["app2"]), APP_JSONS["app2"])
+        self.assertEqual(qiwis.dumps(APP_INFOS["app1"]), APP_JSONS["app1"])
+        self.assertEqual(qiwis.dumps(APP_INFOS["app2"]), APP_JSONS["app2"])
 
     def test_add_to_path(self):
         test_dir = "/test_dir"
         old_path = sys.path.copy()
-        with qiwi._add_to_path(test_dir):
+        with qiwis._add_to_path(test_dir):
             self.assertNotEqual(old_path, sys.path)
             self.assertIn(test_dir, sys.path)
         self.assertEqual(old_path, sys.path)
 
     @mock.patch.object(sys, "argv", ["", "-s", "test_setup.json"])
     def test_get_argparser(self):
-        parser = qiwi._get_argparser()
+        parser = qiwis._get_argparser()
         args = parser.parse_args()
         self.assertEqual(args.setup_path, "test_setup.json")
 
     @mock.patch.object(sys, "argv", [""])
     def test_get_argparser_default(self):
-        args = qiwi._get_argparser().parse_args()
+        args = qiwis._get_argparser().parse_args()
         self.assertEqual(args.setup_path, "./setup.json")
 
     @mock.patch("builtins.open")
     @mock.patch("json.load", return_value={"app": APP_DICTS})
     def test_read_setup_file(self, mock_load, mock_open):
-        self.assertEqual(qiwi._read_setup_file(""), APP_INFOS)
+        self.assertEqual(qiwis._read_setup_file(""), APP_INFOS)
         mock_open.assert_called_once()
         mock_load.assert_called_once()
 
-    @mock.patch("qiwi._get_argparser")
-    @mock.patch("qiwi._read_setup_file", return_value={})
-    @mock.patch("qiwi.Qiwi")
-    @mock.patch("qiwi.QApplication")
-    def test_main(self, mock_qapp, mock_qiwi, mock_read_setup_file, mock_get_argparser):
-        qiwi.main()
+    @mock.patch("qiwis._get_argparser")
+    @mock.patch("qiwis._read_setup_file", return_value={})
+    @mock.patch("qiwis.Qiwi")
+    @mock.patch("qiwis.QApplication")
+    def test_main(self, mock_qapp, mock_qiwis, mock_read_setup_file, mock_get_argparser):
+        qiwis.main()
         mock_get_argparser.assert_called_once()
         mock_read_setup_file.assert_called_once()
-        mock_qiwi.assert_called_once()
+        mock_qiwis.assert_called_once()
         mock_qapp.return_value.exec_.assert_called_once()
 
 

--- a/test.py
+++ b/test.py
@@ -59,8 +59,8 @@ APP_JSONS = {
 qapp = QApplication(sys.argv)
 
 
-class QiwiTestWithApps(unittest.TestCase):
-    """Unit test for Qiwi class with creating apps."""
+class QiwisTestWithApps(unittest.TestCase):
+    """Unit test for Qiwis class with creating apps."""
 
     def setUp(self):
         self.import_module_patcher = mock.patch("importlib.import_module")
@@ -74,7 +74,7 @@ class QiwiTestWithApps(unittest.TestCase):
         self.channels = set()
         for appInfo in APP_INFOS.values():
             self.channels.update(appInfo.channel)
-        self.qiwis = qiwis.Qiwi(APP_INFOS)
+        self.qiwis = qiwis.Qiwis(APP_INFOS)
 
     def doCleanups(self):
         self.import_module_patcher.stop()
@@ -158,11 +158,11 @@ class QiwiTestWithApps(unittest.TestCase):
             self.assertEqual(len(APP_INFOS[name].channel), app_.received.emit.call_count)
 
 
-class QiwiTestWithoutApps(unittest.TestCase):
-    """Unit test for Qiwi class without apps."""
+class QiwisTestWithoutApps(unittest.TestCase):
+    """Unit test for Qiwis class without apps."""
 
     def setUp(self):
-        self.qiwis = qiwis.Qiwi()
+        self.qiwis = qiwis.Qiwis()
 
     def help_qiwiscall(
         self,
@@ -184,11 +184,11 @@ class QiwiTestWithoutApps(unittest.TestCase):
               qiwis.dumps() should be the same as the lenght of the given iterable.
         """
         msg = json.dumps({"call": "callForTest", "args": {}})
-        with mock.patch.multiple(self.qiwis, _handleQiwicall=mock.DEFAULT, _apps=mock.DEFAULT):
+        with mock.patch.multiple(self.qiwis, _handleQiwiscall=mock.DEFAULT, _apps=mock.DEFAULT):
             if error is None:
-                self.qiwis._handleQiwicall.return_value = value
+                self.qiwis._handleQiwiscall.return_value = value
             else:
-                self.qiwis._handleQiwicall.side_effect = error
+                self.qiwis._handleQiwiscall.side_effect = error
             with mock.patch("qiwis.dumps") as mocked_dumps:
                 mocked_dumps.side_effect = dumps
                 self.qiwis._qiwiscall(sender="sender", msg=msg)
@@ -265,22 +265,22 @@ class QiwiTestWithoutApps(unittest.TestCase):
 
 @mock.patch("qiwis.loads")
 @mock.patch("qiwis.QMessageBox.warning")
-class HandleQiwicallTest(unittest.TestCase):
-    """Unit test for Qiwi._handleQiwicall()."""
+class HandleQiwiscallTest(unittest.TestCase):
+    """Unit test for Qiwis._handleQiwiscall()."""
 
     def setUp(self):
-        self.qiwis = qiwis.Qiwi()
+        self.qiwis = qiwis.Qiwis()
 
     def test_ok(self, mocked_warning, mocked_loads):
         args = {"a": 123, "b": "ABC"}
-        info = qiwis.QiwicallInfo(call="callForTest", args=args)
+        info = qiwis.QiwiscallInfo(call="callForTest", args=args)
         msg = json.dumps({"call": "callForTest", "args": args})
         mocked_loads.return_value = info
         mocked_warning.return_value = QMessageBox.Ok
         with mock.patch.multiple(self.qiwis, create=True,
                                  callForTest=mock.DEFAULT, _parseArgs=mock.DEFAULT):
             self.qiwis._parseArgs.return_value = args
-            self.qiwis._handleQiwicall(sender="sender", msg=msg)
+            self.qiwis._handleQiwiscall(sender="sender", msg=msg)
             self.qiwis.callForTest.assert_called_once_with(**args)
             self.qiwis._parseArgs.assert_called_once_with(self.qiwis.callForTest, args)
         mocked_loads.assert_called_once()
@@ -288,7 +288,7 @@ class HandleQiwicallTest(unittest.TestCase):
 
     def test_cancel(self, mocked_warning, mocked_loads):
         args = {"a": 123, "b": "ABC"}
-        info = qiwis.QiwicallInfo(call="callForTest", args=args)
+        info = qiwis.QiwiscallInfo(call="callForTest", args=args)
         msg = json.dumps({"call": "callForTest", "args": args})
         mocked_loads.return_value = info
         mocked_warning.return_value = QMessageBox.Cancel
@@ -296,7 +296,7 @@ class HandleQiwicallTest(unittest.TestCase):
                                  callForTest=mock.DEFAULT, _parseArgs=mock.DEFAULT):
             self.qiwis._parseArgs.return_value = args
             with self.assertRaises(RuntimeError):
-                self.qiwis._handleQiwicall(sender="sender", msg=msg)
+                self.qiwis._handleQiwiscall(sender="sender", msg=msg)
             self.qiwis.callForTest.assert_not_called()
             self.qiwis._parseArgs.assert_called_once_with(self.qiwis.callForTest, args)
         mocked_loads.assert_called_once()
@@ -304,13 +304,13 @@ class HandleQiwicallTest(unittest.TestCase):
 
     def test_non_public(self, mocked_warning, mocked_loads):
         args = {"a": 123, "b": "ABC"}
-        info = qiwis.QiwicallInfo(call="_callForTest", args=args)
+        info = qiwis.QiwiscallInfo(call="_callForTest", args=args)
         msg = json.dumps({"call": "_callForTest", "args": args})
         mocked_loads.return_value = info
         with mock.patch.multiple(self.qiwis, create=True,
                                  _callForTest=mock.DEFAULT, _parseArgs=mock.DEFAULT):
             with self.assertRaises(ValueError):
-                self.qiwis._handleQiwicall(sender="sender", msg=msg)
+                self.qiwis._handleQiwiscall(sender="sender", msg=msg)
             self.qiwis._callForTest.assert_not_called()
             self.qiwis._parseArgs.assert_not_called()
         mocked_loads.assert_called_once()
@@ -318,12 +318,12 @@ class HandleQiwicallTest(unittest.TestCase):
 
     def test_not_existing_method(self, mocked_warning, mocked_loads):
         args = {"a": 123, "b": "ABC"}
-        info = qiwis.QiwicallInfo(call="callForTest", args=args)
+        info = qiwis.QiwiscallInfo(call="callForTest", args=args)
         msg = json.dumps({"call": "callForTest", "args": args})
         mocked_loads.return_value = info
         with mock.patch.multiple(self.qiwis, create=True, _parseArgs=mock.DEFAULT):
             with self.assertRaises(AttributeError):
-                self.qiwis._handleQiwicall(sender="sender", msg=msg)
+                self.qiwis._handleQiwiscall(sender="sender", msg=msg)
             self.qiwis._parseArgs.assert_not_called()
         mocked_loads.assert_called_once()
         mocked_warning.assert_not_called()
@@ -366,27 +366,27 @@ class BaseAppTest(unittest.TestCase):
 
     def test_received_qiwiscall_result(self):
         self.app.qiwiscall.update_result = mock.MagicMock()
-        self.app._receivedQiwicallResult(
+        self.app._receivedQiwiscallResult(
             "request", '{"done": true, "success": true, "value": null, "error": null}'
         )
         self.app.qiwiscall.update_result.assert_called_once_with(
             "request",
-            qiwis.QiwicallResult(done=True, success=True)
+            qiwis.QiwiscallResult(done=True, success=True)
         )
 
     def test_received_qiwiscall_result_exception(self):
         self.app.qiwiscall.update_result = mock.MagicMock()
-        self.app._receivedQiwicallResult(
+        self.app._receivedQiwiscallResult(
             "request", '{"done": "tr" "ue", "success": true, "value": null, "error": null}'
         )
         self.app.qiwiscall.update_result.assert_not_called()
 
 
-class QiwicallProxyTest(unittest.TestCase):
-    """Unit test for QiwicallProxy class."""
+class QiwiscallProxyTest(unittest.TestCase):
+    """Unit test for QiwiscallProxy class."""
 
     def setUp(self):
-        self.qiwiscall = qiwis.QiwicallProxy(mock.MagicMock())
+        self.qiwiscall = qiwis.QiwiscallProxy(mock.MagicMock())
 
     def help_proxy(self, msg: str, args: Mapping[str, Any], dumps: Iterable):
         """Helper method for testing proxy.
@@ -405,7 +405,7 @@ class QiwicallProxyTest(unittest.TestCase):
                 self.assertEqual(len(mocked_dumps.mock_calls), len(dumps))
             self.qiwiscall.requested.emit.assert_called_once_with(msg)
             self.assertIs(result, self.qiwiscall.results[msg])
-            self.assertEqual(result, qiwis.QiwicallResult(done=False, success=False))
+            self.assertEqual(result, qiwis.QiwiscallResult(done=False, success=False))
 
     def test_proxy_primitive(self):
         """Tests a proxied qiwiscall with primitive type arguments."""
@@ -451,28 +451,28 @@ class QiwicallProxyTest(unittest.TestCase):
                 (mock.call(msg), mock.call(msg)),
             )
             self.assertIs(result2, self.qiwiscall.results[msg])
-            self.assertEqual(result2, qiwis.QiwicallResult(done=False, success=False))
+            self.assertEqual(result2, qiwis.QiwiscallResult(done=False, success=False))
             self.assertEqual(result1, result2)
 
     def test_update_result_success(self):
-        old_result = qiwis.QiwicallResult(done=False, success=False)
-        new_result = qiwis.QiwicallResult(done=True, success=True, value=0)
+        old_result = qiwis.QiwiscallResult(done=False, success=False)
+        new_result = qiwis.QiwiscallResult(done=True, success=True, value=0)
         with mock.patch.object(self.qiwiscall, "results", {"request": old_result}):
             self.qiwiscall.update_result("request", new_result)
             self.assertEqual(old_result, new_result)
             self.assertNotIn("request", self.qiwiscall.results)
 
     def test_update_result_error(self):
-        old_result = qiwis.QiwicallResult(done=False, success=False)
-        new_result = qiwis.QiwicallResult(done=True, success=False, error=RuntimeError("test"))
+        old_result = qiwis.QiwiscallResult(done=False, success=False)
+        new_result = qiwis.QiwiscallResult(done=True, success=False, error=RuntimeError("test"))
         with mock.patch.object(self.qiwiscall, "results", {"request": old_result}):
             self.qiwiscall.update_result("request", new_result)
             self.assertEqual(old_result, new_result)
             self.assertNotIn("request", self.qiwiscall.results)
 
     def test_update_result_no_discard(self):
-        old_result = qiwis.QiwicallResult(done=False, success=False)
-        new_result = qiwis.QiwicallResult(done=True, success=True, value=0)
+        old_result = qiwis.QiwiscallResult(done=False, success=False)
+        new_result = qiwis.QiwiscallResult(done=True, success=True, value=0)
         with mock.patch.object(self.qiwiscall, "results", {"request": old_result}):
             self.qiwiscall.update_result("request", new_result, discard=False)
             self.assertEqual(old_result, new_result)
@@ -480,13 +480,13 @@ class QiwicallProxyTest(unittest.TestCase):
 
     def test_update_result_not_exist(self):
         """When the request is not in the results dictionary, it is ignored."""
-        new_result = qiwis.QiwicallResult(done=True, success=True, value=0)
+        new_result = qiwis.QiwiscallResult(done=True, success=True, value=0)
         with mock.patch.object(self.qiwiscall, "results", {}):
             self.qiwiscall.update_result("request", new_result)
             self.assertNotIn("request", self.qiwiscall.results)
 
 
-class QiwiFunctionTest(unittest.TestCase):
+class QiwisFunctionTest(unittest.TestCase):
     """Unit test for functions."""
 
     def test_loads(self):
@@ -525,7 +525,7 @@ class QiwiFunctionTest(unittest.TestCase):
 
     @mock.patch("qiwis._get_argparser")
     @mock.patch("qiwis._read_setup_file", return_value={})
-    @mock.patch("qiwis.Qiwi")
+    @mock.patch("qiwis.Qiwis")
     @mock.patch("qiwis.QApplication")
     def test_main(self, mock_qapp, mock_qiwis, mock_read_setup_file, mock_get_argparser):
         qiwis.main()


### PR DESCRIPTION
As we discussed in #156, we finally decided this project name as `qiwis`, "QuIqcl Widget Integration Software".
I replaced all `qiwi` with `qiwis`.

This will close #156.